### PR TITLE
Try to not use type on error

### DIFF
--- a/lib/CustomError.js
+++ b/lib/CustomError.js
@@ -1,8 +1,8 @@
 function CustomError(message, previousError) {
     this.previousError = previousError;
-    this.type = this.constructor.name;
+    this.typeName = this.constructor.name;
     this.message = message || "";
-    this.stack = getRelevantStackTrace(new Error().stack, message, this.type);
+    this.stack = getRelevantStackTrace(new Error().stack, message, this.typeName);
 }
 
 function getRelevantStackTrace(fullStackTrace, message, type) {
@@ -24,7 +24,7 @@ CustomError.prototype.is = function(ErrorType) {
     }
 
     var errorType = new ErrorType();
-    return (this.type == errorType.type);
+    return (this.typeName == errorType.typeName);
 };
 
 CustomError.prototype.toString = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube-error",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Custom errors",
   "main": "index.js",
   "scripts": {

--- a/spec/ConflictErrorSpec.js
+++ b/spec/ConflictErrorSpec.js
@@ -28,7 +28,7 @@ describe("ConflictError", function() {
 
     it("has a type", function() {
         var e = new ConflictError();
-        expect(e.type).toEqual("ConflictError");
+        expect(e.typeName).toEqual("ConflictError");
     });
 
     it("can be matched with `is`", function() {

--- a/spec/HttpErrorSpec.js
+++ b/spec/HttpErrorSpec.js
@@ -15,7 +15,7 @@ describe("HttpError", function() {
     it("returns a NotFoundError if status code is 404", function() {
         var e = new HttpError(404);
         expect(e.is(NotFoundError)).toBeTruthy();
-        expect(e.type).toEqual("NotFoundError");
+        expect(e.typeName).toEqual("NotFoundError");
     });
 
     it("defaults to an empty string if it has no message", function() {
@@ -40,7 +40,7 @@ describe("HttpError", function() {
 
     it("has a type", function() {
         var e = new HttpError(500);
-        expect(e.type).toEqual("HttpError");
+        expect(e.typeName).toEqual("HttpError");
     });
 
     it("can be matched with `is`", function() {

--- a/spec/InvalidArgumentErrorSpec.js
+++ b/spec/InvalidArgumentErrorSpec.js
@@ -28,7 +28,7 @@ describe("InvalidArgumentError", function() {
 
     it("has a type", function() {
         var e = new InvalidArgumentError();
-        expect(e.type).toEqual("InvalidArgumentError");
+        expect(e.typeName).toEqual("InvalidArgumentError");
     });
 
     it("has a 'invalidArgument' property", function() {

--- a/spec/NotFoundErrorSpec.js
+++ b/spec/NotFoundErrorSpec.js
@@ -28,7 +28,7 @@ describe("NotFoundError", function() {
 
     it("has a type", function() {
         var e = new NotFoundError();
-        expect(e.type).toEqual("NotFoundError");
+        expect(e.typeName).toEqual("NotFoundError");
     });
 
     it("can be matched with `is`", function() {


### PR DESCRIPTION
`type` was reserved on Error objects back in 0.10, so we'll try to distinguish and not use that var name on our custom errors... though it shouldn't really change much.