### PR TITLE
Added a 'missing argument' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation
 ------------
 
     npm install cube-error --save
-    
+
 Usage
 -----
 
@@ -47,6 +47,8 @@ We currently support these errors:
   Otherwise returns a `HttpError` with a `statusCode` field.
 - `Conflict(message, previousError)`:
   Used when a resource modification conflicts with existing internal state.
+- `MissingArgument(message, previousError)`:
+  Can be used when arguments were expected but not passed. 
 - `InvalidArgument(invalidArgumentName, message, previousError)`:
   Can be used as a custom `TypeError` to indicate unexpected input-type or value
   The error has a `invalidArgument`-field which stores the value of `invalidArgumentName`

--- a/index.js
+++ b/index.js
@@ -4,5 +4,6 @@ module.exports = {
     Custom: require("./lib/CustomError.js"),
     is: require("./lib/is.js"),
     Conflict: require("./lib/ConflictError.js"),
-    InvalidArgument: require("./lib/InvalidArgumentError.js")
+    InvalidArgument: require("./lib/InvalidArgumentError.js"),
+    MissingArgument: require("./lib/MissingArgumentError.js")
 };

--- a/lib/MissingArgumentError.js
+++ b/lib/MissingArgumentError.js
@@ -1,0 +1,9 @@
+var CustomError = require("./CustomError.js");
+var util = require("util");
+
+function MissingArgumentError(message, previousError) {
+    CustomError.call(this, message, previousError);
+}
+util.inherits(MissingArgumentError, CustomError);
+
+module.exports = MissingArgumentError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube-error",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Custom errors",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     {
       "name": "Sven Johansen Hermann",
       "email": "sjh@cubeio.com"
+    },
+    {
+      "name": "Asbjørn Thegler",
+      "email": "at@cubeio.com"
     }
   ],
   "license": "ISC",

--- a/spec/MissingArgumentErrorSpec.js
+++ b/spec/MissingArgumentErrorSpec.js
@@ -1,0 +1,44 @@
+var MissingArgumentError = require("../index.js").MissingArgument;
+
+describe("MissingArgumentError", function() {
+    it("has a message", function() {
+        var e = new MissingArgumentError("hello, world");
+        expect(e.message).toEqual("hello, world");
+    });
+
+    it("defaults to an empty string if it has no message", function() {
+        var e = new MissingArgumentError();
+        expect(e.message).toEqual("");
+    });
+
+    it("has a stack trace", function() {
+        var e = new MissingArgumentError("hello kitty");
+        expect(e.stack).toMatch(/^MissingArgumentError: hello kitty/);
+    });
+
+    it("has a previous error", function() {
+        var innerError = {
+            message: "something",
+            statusCode: 1337,
+            psudo: "error much"
+        };
+        var e = new MissingArgumentError("Got pseudo-error from couch", innerError);
+        expect(e.previousError).toEqual(innerError);
+    });
+
+    it("has a type", function() {
+        var e = new MissingArgumentError();
+        expect(e.typeName).toEqual("MissingArgumentError");
+    });
+
+    it("can be matched with `is`", function() {
+        var e = new MissingArgumentError();
+        expect(e.is(MissingArgumentError)).toBeTruthy();
+    });
+
+    it("converts to its stacktrace when printed", function() {
+        var e = new MissingArgumentError("hello");
+        var eAsString = "Found this error: " + e;
+        expect(eAsString).toEqual("Found this error: " + e.stack);
+    });
+});


### PR DESCRIPTION
This adds a new error type to our custom error package.

I need to be able to recognize when an invalid argument is passed, and when it is merely missing. It is true that one can risk passing an `undefined` value, which will be recognized as missing, but I still believe this change to be justified.