### PR TITLE
Fix for node5

### DIFF
--- a/lib/CustomError.js
+++ b/lib/CustomError.js
@@ -5,8 +5,6 @@ function CustomError(message, previousError) {
     this.stack = getRelevantStackTrace(new Error().stack, message, this.typeName);
 }
 
-CustomError.prototype = new Error;
-
 function getRelevantStackTrace(fullStackTrace, message, type) {
     var matchConstructorStackFrame = new RegExp("new " + type + "[^\n]+\n", "g");
     var constructorStackFrameLine = matchConstructorStackFrame.exec(fullStackTrace);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cube-error",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "Custom errors",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Custom errors",
   "main": "index.js",
   "scripts": {
-    "test": "node node_modules/.bin/jasmine"
+    "test": "node node_modules/jasmine/bin/jasmine.js"
   },
   "repository": {
     "type": "git",

--- a/spec/ConflictErrorSpec.js
+++ b/spec/ConflictErrorSpec.js
@@ -41,9 +41,4 @@ describe("ConflictError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new ConflictError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/CustomErrorSpec.js
+++ b/spec/CustomErrorSpec.js
@@ -8,6 +8,6 @@ describe("CustomError", function() {
 
     it("has a type", function() {
         var e = new CustomError();
-        expect(e.typeName).toEqual("Error");
+        expect(e.typeName).toEqual("CustomError");
     });
 });

--- a/spec/CustomErrorSpec.js
+++ b/spec/CustomErrorSpec.js
@@ -1,9 +1,9 @@
 var CustomError = require("../index.js").Custom;
 
 describe("CustomError", function() {
-    it("has no stack trace", function() {
+    it("has a stack trace", function() {
         var e = new CustomError("pokemón gotta catch them all");
-        expect(e.stack).toBe("");
+        expect(e.stack).toMatch(/^CustomError: pokemón gotta catch them all/);
     });
 
     it("has a type", function() {

--- a/spec/CustomErrorSpec.js
+++ b/spec/CustomErrorSpec.js
@@ -10,9 +10,4 @@ describe("CustomError", function() {
         var e = new CustomError();
         expect(e.typeName).toEqual("Error");
     });
-
-    it("is an instance of Error", function() {
-        var e = new CustomError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/HttpErrorSpec.js
+++ b/spec/HttpErrorSpec.js
@@ -53,9 +53,4 @@ describe("HttpError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new HttpError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/InternalErrorSpec.js
+++ b/spec/InternalErrorSpec.js
@@ -41,9 +41,4 @@ describe("InternalError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new InternalError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/InvalidArgumentErrorSpec.js
+++ b/spec/InvalidArgumentErrorSpec.js
@@ -51,9 +51,4 @@ describe("InvalidArgumentError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new InvalidArgumentError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/MissingArgumentErrorSpec.js
+++ b/spec/MissingArgumentErrorSpec.js
@@ -41,9 +41,4 @@ describe("MissingArgumentError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new MissingArgumentError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });

--- a/spec/NotFoundErrorSpec.js
+++ b/spec/NotFoundErrorSpec.js
@@ -41,9 +41,4 @@ describe("NotFoundError", function() {
         var eAsString = "Found this error: " + e;
         expect(eAsString).toEqual("Found this error: " + e.stack);
     });
-
-    it("is an instance of Error", function() {
-        var e = new NotFoundError();
-        expect(e instanceof Error).toBeTruthy();
-    });
 });


### PR DESCRIPTION
Remove Error inheritance

> This turns out to break in node5 (it didn't in node 0.11.13, where we were
using this lib).
> 
> Basically, inheriting from Error overwrites the `this.stack` field and
does not let anything else write to it. This means that the "original"
(inner, unmodified) stacktrace will still be gotten from the error, which
is one of the main things we're trying to avoid with this lib.
> 
> Unfortunately this means that `someCubeError instanceof Error` will no
longer work. Should be a major bump.